### PR TITLE
Auth to recipe create

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,9 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  private 
+
+  def not_authenticated
+    redirect_to main_app.login_path
+  end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,4 +1,6 @@
 class RecipesController < ApplicationController
+  before_action :require_login, only: [:new,:create]
+
   def index
     @recipe = Recipe.all
   end
@@ -12,7 +14,6 @@ class RecipesController < ApplicationController
   end
 
   def create
-    #since we don't have auth for this action right now will break if we do this while not logged in
     @recipe = current_user.recipes.create(recipe_params)
     if @recipe.save
       redirect_to recipe_path(id:@recipe.id)

--- a/spec/controllers/recipes_controller_spec.rb
+++ b/spec/controllers/recipes_controller_spec.rb
@@ -11,10 +11,18 @@ RSpec.describe RecipesController, type: :controller do
   end
 
   describe "recipes#new" do
-    it "should show the new recipes page" do
+    it "should show the new recipes page if I am logged in" do
+      user = FactoryGirl.create(:user)
+      login_user(user)
       get :new
 
       expect(response).to have_http_status(:success)
+    end
+
+    it "shouldn't let not logged in users to view the new recipe page" do
+      get :new
+
+      expect(response).to redirect_to login_path
     end
   end
   

--- a/spec/controllers/recipes_controller_spec.rb
+++ b/spec/controllers/recipes_controller_spec.rb
@@ -38,5 +38,12 @@ RSpec.describe RecipesController, type: :controller do
       expect(recipe.description).to eq("food")
       expect(recipe.users.last).to eq(user)
     end
+
+    it "shouldn't allow us to create a recipe if we are not logged in" do
+      post :create, params: { recipe: { name: "recipe", description:"another one" } }
+
+      expect(response).to redirect_to login_path
+      expect(Recipe.count).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
Added a before filter to check if a user is logged in before accessing the recipe new or create pages. If they are not they will be redirected to the log in page. 